### PR TITLE
Correct aspect ratio for 240p and crop overscan

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ pub struct Options {
     gpu_viewer: GpuViewerOptions,
 
     scaling: Scaling,
+    crop_overscan: bool,
 
     pause: bool,
     step: bool,
@@ -87,6 +88,7 @@ fn main() {
         },
 
         scaling: Scaling::Aspect,
+        crop_overscan: true,
 
         pause: false,
         step: false,

--- a/src/psx/gpu.rs
+++ b/src/psx/gpu.rs
@@ -476,7 +476,7 @@ impl Gpu {
         let mut y = yend - ystart;
 
         if self.vertical_interlace {
-            y <<= 1;
+            y *= 2;
         }
 
         (x, y)
@@ -485,15 +485,20 @@ impl Gpu {
     pub fn get_framebuffer(&self,
                            framebuffer: &mut [u8],
                            draw_full_vram: bool) {
-
         let (xs, ys) = if draw_full_vram {
             (0, 0)
         } else {
-            self.get_display_origin()
+            let (mut x, mut y) = self.get_display_origin();
+
+            // Adjust start based on CRTC registers
+            x += (self.horizontal_display_start - 608) / self.get_dotclock();
+            y += (self.vertical_display_start - 16) * 2;
+
+            (x, y)
         };
 
         let (w, h) = if draw_full_vram {
-            (1024, 512)
+            (0, 0)
         } else {
             self.get_display_size()
         };


### PR DESCRIPTION
The screen ratio is now calculated based on a 640x480 display resolution regardless of the rendering resolution.
Also added an option to crop the overscan region and scale the display accordingly. (F9)

Fixes #8 